### PR TITLE
feat(core): Define core protocol types and interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ packages/*/docs
 !.yarn/sdks
 !.yarn/versions
 
+.next
+.yarn
+
 # typescript
 packages/*/*.tsbuildinfo
 

--- a/packages/core/src/domain/key-manager.ts
+++ b/packages/core/src/domain/key-manager.ts
@@ -1,0 +1,10 @@
+import type { KeyPair } from "./key-pair";
+
+/**
+ * A key manager is responsible for generating key pairs, encrypting and decrypting messages.
+ */
+export interface IKeyManager {
+	generateKeyPair(): KeyPair;
+	encrypt(plaintext: string, theirPublicKey: Uint8Array): Promise<string>;
+	decrypt(encryptedB64: string, myPrivateKey: Uint8Array): Promise<string>;
+}

--- a/packages/core/src/domain/key-pair.ts
+++ b/packages/core/src/domain/key-pair.ts
@@ -1,0 +1,7 @@
+/**
+ * Represents a cryptographic key pair.
+ */
+export type KeyPair = {
+	publicKey: Uint8Array;
+	privateKey: Uint8Array;
+};

--- a/packages/core/src/domain/kv-store.ts
+++ b/packages/core/src/domain/kv-store.ts
@@ -1,0 +1,8 @@
+/**
+ * Defines a persistent, asynchronous key-value storage interface.
+ */
+export interface IKVStore {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string): Promise<void>;
+	delete(key: string): Promise<void>;
+}

--- a/packages/core/src/domain/protocol-message.ts
+++ b/packages/core/src/domain/protocol-message.ts
@@ -1,0 +1,33 @@
+/**
+ * The handshake message sent by the wallet to the dApp.
+ * Its payload is part of the protocol itself and should be strongly typed.
+ */
+export type WalletHandshake = {
+	type: "wallet-handshake";
+	payload: {
+		publicKeyB64: string;
+	};
+};
+
+/**
+ * A generic request sent from the dApp to the wallet.
+ * The payload is application-defined.
+ */
+export type DappRequest = {
+	type: "dapp-request";
+	payload: unknown;
+};
+
+/**
+ * A generic response sent from the wallet to the dApp.
+ * The payload is application-defined.
+ */
+export type WalletResponse = {
+	type: "wallet-response";
+	payload: unknown;
+};
+
+/**
+ * A union of all possible protocol messages.
+ */
+export type ProtocolMessage = WalletHandshake | DappRequest | WalletResponse;

--- a/packages/core/src/domain/session-request.ts
+++ b/packages/core/src/domain/session-request.ts
@@ -1,0 +1,7 @@
+/**
+ * A session request is a message sent by the dApp to the wallet to initiate a session.
+ */
+export type SessionRequest = {
+	id: string;
+	publicKeyB64: string;
+};

--- a/packages/core/src/domain/session.ts
+++ b/packages/core/src/domain/session.ts
@@ -1,0 +1,13 @@
+import type { KeyPair } from "./key-pair";
+
+/**
+ * A session is a unique identifier for a connection between two parties.
+ * It contains the key pair for the local party, the public key of the remote party,
+ * and the expiration time of the session.
+ */
+export type Session = {
+	id: string;
+	keyPair: KeyPair;
+	theirPublicKey: Uint8Array;
+	expiresAt: number;
+};

--- a/packages/core/src/domain/transport.ts
+++ b/packages/core/src/domain/transport.ts
@@ -1,0 +1,44 @@
+/**
+ * Defines the contract for a communication transport.
+ * This allows the protocol to be agnostic to the underlying
+ * communication mechanism (e.g., WebSocket, Deep Link).
+ *
+ * It is designed around a simple, channel-based publish/subscribe model.
+ */
+export interface ITransport {
+	/**
+	 * Establishes a connection.
+	 * Returns a promise that resolves when the connection is established.
+	 */
+	connect(): Promise<void>;
+
+	/**
+	 * Disconnects.
+	 * Returns a promise that resolves when the connection is closed.
+	 */
+	disconnect(): Promise<void>;
+
+	/**
+	 * Publishes a message to a specific channel.
+	 * @param channel The channel to publish the message to.
+	 * @param message The message payload to send.
+	 * Returns a promise that resolves when the message is published.
+	 */
+	publish(channel: string, message: string): Promise<void>;
+
+	/**
+	 * Subscribes to a channel to begin receiving messages.
+	 * @param channel The channel to subscribe to.
+	 * Returns a promise that resolves when the subscription is established.
+	 */
+	subscribe(channel: string): Promise<void>;
+
+	/**
+	 * Listens for incoming events from the transport.
+	 * @param event The name of the event to listen for.
+	 * @param handler The callback function to execute.
+	 */
+	on(event: "message", handler: (payload: { channel: string; data: string }) => void): void;
+	on(event: "connected" | "disconnected", handler: () => void): void;
+	on(event: "error", handler: (error: Error) => void): void;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,10 +4,15 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		include: ["packages/**/*.test.ts"],
+		coverage: {
+			include: ["packages/**/*.ts"],
+		},
 	},
 	resolve: {
 		alias: {
 			"@metamask/mobile-wallet-protocol-core": path.resolve(__dirname, "./packages/core/src"),
+			"@metamask/mobile-wallet-protocol-dapp-client": path.resolve(__dirname, "./packages/dapp-client/src"),
+			"@metamask/mobile-wallet-protocol-wallet-client": path.resolve(__dirname, "./packages/wallet-client/src"),
 		},
 	},
 });


### PR DESCRIPTION
This PR defines the essential types and interfaces for the protocol. 

- **ADDED:**
  - **Core Service Interfaces:** `ITransport` (communication), `IKeyManager` (cryptography), and `IKVStore` (persistent storage).
  - **Domain Data Models:** `KeyPair`, `Session`, `SessionRequest`, and a `ProtocolMessage` union to model the protocol's data structures and message formats.

- **CHANGED:**
  - `vitest.config.ts`: Updated with path aliases for new packages to support testing.
  - `.gitignore`: Added common build and cache directories (`.next`, `.yarn`).

**Checklist**

- [x] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves #???