### PR TITLE
Optimistic trusted flow

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -76,3 +76,9 @@ graph TD
     DappClient --> Core
     WalletClient --> Core
 ```
+
+## Notes
+
+A key feature of the protocol, particularly in `trusted` mode, is its support for asynchronous/optimistic connections. 
+
+This is critical for same-device flows (e.g., a dApp in a mobile browser deep-linking to the wallet app). In this scenario, the mobile OS will freeze the dApp's process. The protocol is designed to handle this by allowing the wallet to establish its side of the connection optimistically, without waiting for a real-time reply from the frozen dApp. When the user returns, the dApp wakes up, processes the historical handshake message from the relay server, and finalizes the connection.

--- a/packages/dapp-client/src/client.ts
+++ b/packages/dapp-client/src/client.ts
@@ -20,7 +20,8 @@ import type { IConnectionHandlerContext } from "./domain/connection-handler-cont
 import { TrustedConnectionHandler } from "./handlers/trusted-connection-handler";
 import { UntrustedConnectionHandler } from "./handlers/untrusted-connection-handler";
 
-const SESSION_REQUEST_TTL = 60 * 1000; // 60 seconds
+export const SESSION_REQUEST_TTL = 60 * 1000; // 60 seconds
+export const HANDSHAKE_TIMEOUT = 60 * 1000; // 60 seconds
 
 /**
  * Configuration options for the DappClient.

--- a/packages/dapp-client/src/handlers/trusted-connection-handler.test.ts
+++ b/packages/dapp-client/src/handlers/trusted-connection-handler.test.ts
@@ -74,10 +74,7 @@ t.describe("TrustedConnectionHandler", () => {
 		t.expect(context.transport.connect).toHaveBeenCalledOnce();
 		t.expect(context.transport.subscribe).toHaveBeenCalledWith(mockRequest.channel);
 		t.expect(context.emit).not.toHaveBeenCalledWith("otp_required", t.expect.any(Object));
-		t.expect(context.sendMessage).not.toHaveBeenCalledWith(
-			t.expect.stringContaining("session:secure-channel"),
-			{ type: "handshake-ack" },
-		);
+		t.expect(context.sendMessage).not.toHaveBeenCalledWith(t.expect.stringContaining("session:secure-channel"), { type: "handshake-ack" });
 		t.expect(context.sessionstore.set).toHaveBeenCalledOnce();
 		t.expect(context.transport.clear).toHaveBeenCalledWith(mockRequest.channel);
 		t.expect(context.state).toBe("CONNECTED");

--- a/packages/wallet-client/src/handlers/trusted-connection-handler.test.ts
+++ b/packages/wallet-client/src/handlers/trusted-connection-handler.test.ts
@@ -118,10 +118,7 @@ t.describe("TrustedConnectionHandler", () => {
 		await handler.execute(mockSession, mockRequest);
 
 		t.expect(sendMessageSpy).toHaveBeenCalledOnce();
-		t.expect(sendMessageSpy).toHaveBeenCalledWith(
-			mockRequest.channel,
-			t.expect.objectContaining({ type: "handshake-offer" }),
-		);
+		t.expect(sendMessageSpy).toHaveBeenCalledWith(mockRequest.channel, t.expect.objectContaining({ type: "handshake-offer" }));
 	});
 
 	t.test("should process a valid initialMessage after finalizing connection", async () => {

--- a/packages/wallet-client/src/handlers/trusted-connection-handler.ts
+++ b/packages/wallet-client/src/handlers/trusted-connection-handler.ts
@@ -4,17 +4,20 @@ import type { IConnectionHandler } from "../domain/connection-handler";
 import type { IConnectionHandlerContext } from "../domain/connection-handler-context";
 
 /**
- * Handles the trusted connection flow for wallets.
+ * Handles the trusted connection flow for wallets in an optimistic, non-blocking manner.
  *
- * This handler implements a simplified connection sequence for same-device
- * or trusted contexts:
- * 1. Connects to transport and subscribes to both handshake and session channels
- * 2. Sends handshake offer without OTP directly to dApp (in a fire-and-forget manner)
- * 3. Finalizes connection by persisting session and cleaning up
+ * This handler is designed for scenarios like mobile, where the
+ * dApp may be suspended by the OS immediately after sending its request.
  *
- * This flow prioritizes user experience over maximum security, making it
- * ideal for same-device scenarios or pre-trusted contexts where the user
- * has already established trust through other means.
+ * The flow is as follows:
+ * 1. Immediately create and persist the session upon receiving the request.
+ * 2. Connect to the transport and subscribe to the necessary channels.
+ * 3. Send the `handshake-offer` to the dApp in a "fire-and-forget" manner.
+ * 4. The `execute` method resolves immediately, allowing the wallet to consider itself
+ *    `CONNECTED` without waiting for a reply from the dApp.
+ *
+ * This asynchronous approach prevents the wallet from getting stuck waiting for a response
+ * from a dApp that may be frozen, ensuring a reliable connection on same-device platforms.
  */
 export class TrustedConnectionHandler implements IConnectionHandler {
 	private readonly context: IConnectionHandlerContext;


### PR DESCRIPTION
This PR makes the trusted flow optimistic, by making the connection non-blocking on the wallet side. This is needed to enable flows like same device connection with cold starts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make the trusted flow optimistic/non-blocking: wallet finalizes immediately after sending offer; dApp resumes to process historical offer with extended timeout; update docs and tests.
> 
> - **Docs**:
>   - **Trusted flow**: Reframed as passwordless and optimistic; diagrams and phases updated to remove `handshake-ack` and describe same-device suspend/resume behavior.
>   - **Architecture**: Added notes on asynchronous/optimistic connections for mobile deep-link scenarios.
> - **DApp Client** (`packages/dapp-client`):
>   - Export `SESSION_REQUEST_TTL`; add `HANDSHAKE_TIMEOUT` and use combined wait window.
>   - Trusted handler now waits for historical `handshake-offer`, finalizes session, subscribes to `session:*`, clears handshake channel, and does not send `handshake-ack`.
> - **Wallet Client** (`packages/wallet-client`):
>   - Trusted handler made optimistic: set session, subscribe, send `handshake-offer`, persist session, clear handshake channel, emit `connected` without waiting for ack; process `initialMessage` post-connect.
> - **Tests**:
>   - Updated dApp and wallet trusted-flow tests to reflect no ack, extended timeout handling, channel subscriptions, and optimistic resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3623f74e1506114d6918847b4184d28001b88e59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->