### PR TITLE
chore: add build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Follow these steps to run the full end-to-end demo on your machine.
 
 ### Prerequisites
 
-*   **Node.js**: Use version 18.x or later.
-*   **Yarn**: This repository uses Yarn for package management.
-*   **Docker & Docker Compose**: Required to run the backend relay server.
-*   **Expo Go App**: To run the mobile wallet demo, you'll need the [Expo Go](https://expo.dev/go) app on your iOS or Android device.
+- **Node.js**: Use version 18.x or later.
+- **Yarn**: This repository uses Yarn for package management.
+- **Docker & Docker Compose**: Required to run the backend relay server.
+- **Expo Go App**: To run the mobile wallet demo, you'll need the [Expo Go](https://expo.dev/go) app on your iOS or Android device.
 
 ### 1. Installation
 
@@ -23,6 +23,12 @@ Clone the repository and install all dependencies using Yarn.
 git clone https://github.com/your-repo/mobile-wallet-protocol.git
 cd mobile-wallet-protocol
 yarn install
+```
+
+To use the demo apps locally you also have to build the packages.
+
+```bash
+yarn build
 ```
 
 ### 2. Run the Backend Relay Server


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Update README**

- Added a build step to the `README.md`. Running the demo apps without building will result in the `@metamask/mobile-wallet-protocol-core` not existing. 

**Description**

- ADDED:

  - Build step to the README.md

**Checklist**

- [x] Tests are included if applicable
- [x] Any added code is fully documented

**Issue**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `yarn build` step to README for running demo apps locally and cleans up prerequisites list formatting.
> 
> - **Docs** (`README.md`):
>   - Add `yarn build` step after installation to enable running local demo apps.
>   - Clean up prerequisites list formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfff82ccb438d8cb7834dcff980f30e0048752f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->