### PR TITLE
feat: use compressed deep link on Metamask Mobile Demo

### DIFF
--- a/apps/web-demo/src/components/MetaMaskMobileDemo.tsx
+++ b/apps/web-demo/src/components/MetaMaskMobileDemo.tsx
@@ -242,7 +242,7 @@ export default function MetaMaskMobileDemo() {
 				const deepLinkUrl = `metamask://connect/mwp?p=${uriEncodedPayload}`;
 
 				// Also show what the compressed URL would look like
-				const compressedPayload = compressString(jsonPayload);
+				const compressedPayload = encodeURIComponent(compressString(jsonPayload));
 				const compressedDeepLinkUrl = `metamask://connect/mwp?p=${compressedPayload}&c=1`; // c=1 indicates compressed
 
 				console.log("Standard deep link length:", deepLinkUrl.length);

--- a/apps/web-demo/src/components/MetaMaskMobileDemo.tsx
+++ b/apps/web-demo/src/components/MetaMaskMobileDemo.tsx
@@ -248,7 +248,7 @@ export default function MetaMaskMobileDemo() {
 				console.log("Standard deep link length:", deepLinkUrl.length);
 				console.log("Compressed deep link length:", compressedDeepLinkUrl.length);
 
-				setQrCodeData(deepLinkUrl);
+				setQrCodeData(compressedDeepLinkUrl);
 				addDappLog("system", "QR code generated with base64 encoded deep link. Ready for wallet to scan.");
 
 				// Start session timer

--- a/apps/web-demo/src/lib/encoding-utils.ts
+++ b/apps/web-demo/src/lib/encoding-utils.ts
@@ -37,7 +37,7 @@ export function base64Decode(str: string): string {
  * Returns a base64-encoded compressed string
  */
 export function compressString(str: string): string {
-	const compressed = pako.deflateRaw(str);
+	const compressed = pako.deflate(str);
 	// Convert Uint8Array to string for base64 encoding
 	const binaryString = String.fromCharCode.apply(null, Array.from(compressed));
 	return base64Encode(binaryString);
@@ -53,7 +53,7 @@ export function decompressString(compressedBase64: string): string {
 	for (let i = 0; i < binaryString.length; i++) {
 		compressed[i] = binaryString.charCodeAt(i);
 	}
-	const decompressed = pako.inflateRaw(compressed);
+	const decompressed = pako.inflate(compressed);
 	return new TextDecoder().decode(decompressed);
 }
 

--- a/apps/web-demo/src/lib/encoding-utils.ts
+++ b/apps/web-demo/src/lib/encoding-utils.ts
@@ -37,7 +37,7 @@ export function base64Decode(str: string): string {
  * Returns a base64-encoded compressed string
  */
 export function compressString(str: string): string {
-	const compressed = pako.deflate(str);
+	const compressed = pako.deflateRaw(str);
 	// Convert Uint8Array to string for base64 encoding
 	const binaryString = String.fromCharCode.apply(null, Array.from(compressed));
 	return base64Encode(binaryString);
@@ -53,7 +53,7 @@ export function decompressString(compressedBase64: string): string {
 	for (let i = 0; i < binaryString.length; i++) {
 		compressed[i] = binaryString.charCodeAt(i);
 	}
-	const decompressed = pako.inflate(compressed);
+	const decompressed = pako.inflateRaw(compressed);
 	return new TextDecoder().decode(decompressed);
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!

Please ensure that any applicable requirements below are satisfied before submitting this pull request. This will help ensure a quick and efficient review cycle.
-->

**Description**

The goal of this PR is to use deeplink compression logic to decrease size of transported payloads across established connections.

**Checklist**

- [ ] Tests are included if applicable
- [ ] Any added code is fully documented

**Issue**

Resolves https://www.notion.so/metamask-consensys/SDK-Phase-1-End-game-276f86d67d688061a461ee0cbaf37649?p=278f86d67d6880c0a460f671085afbea&pm=s

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch QR code to a compressed deep link and URI-encode the compressed payload parameter.
> 
> - **Frontend (apps/web-demo/src/components/MetaMaskMobileDemo.tsx)**:
>   - **Deep link generation**:
>     - URI-encode the compressed payload: `compressString(jsonPayload)` -> `encodeURIComponent(compressString(jsonPayload))`.
>     - Use the compressed deep link (`metamask://connect/mwp?p=...&c=1`) for the QR code instead of the standard link.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 677bcbc2e3d7a20ba8b4e1b91126fccbf6ba6497. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->