### PR TITLE
fix: prevent nonce poisoning (WAPI-1121)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent nonce poisoning by deferring nonce persistence until after successful decryption ([#69](https://github.com/MetaMask/mobile-wallet-protocol/pull/69))
+- Guard against `NaN` in nonce storage ([#69](https://github.com/MetaMask/mobile-wallet-protocol/pull/69))
 - Fix `SessionStore` race conditions and fire-and-forget garbage collection ([#71](https://github.com/MetaMask/mobile-wallet-protocol/pull/71))
 - Guard against `NaN` in session expiry timestamps ([#70](https://github.com/MetaMask/mobile-wallet-protocol/pull/70))
 

--- a/packages/core/src/base-client.ts
+++ b/packages/core/src/base-client.ts
@@ -46,7 +46,12 @@ export abstract class BaseClient extends EventEmitter {
 		this.transport.on("message", async (payload) => {
 			if (!this.session?.keyPair.privateKey) return;
 			const message = await this.decryptMessage(payload.data);
-			if (message) this.handleMessage(message);
+			if (message) {
+				// Confirm the nonce only after successful decryption to prevent
+				// attackers from poisoning the nonce tracker with invalid messages.
+				await payload.confirmNonce?.();
+				this.handleMessage(message);
+			}
 		});
 	}
 

--- a/packages/core/src/domain/transport.ts
+++ b/packages/core/src/domain/transport.ts
@@ -40,7 +40,7 @@ export interface ITransport {
 	 * @param event The name of the event to listen for.
 	 * @param handler The callback function to execute.
 	 */
-	on(event: "message", handler: (payload: { channel: string; data: string }) => void): void;
+	on(event: "message", handler: (payload: { channel: string; data: string; confirmNonce?: () => Promise<void> }) => void): void;
 	on(event: "connecting" | "connected" | "disconnected", handler: () => void): void;
 	on(event: "error", handler: (error: Error) => void): void;
 

--- a/packages/core/src/transport/websocket/index.ts
+++ b/packages/core/src/transport/websocket/index.ts
@@ -51,6 +51,19 @@ type TransportState = "disconnected" | "connecting" | "connected";
 
 /** The maximum number of messages to fetch from history upon a new subscription. */
 const HISTORY_FETCH_LIMIT = 50;
+/**
+ * Maximum allowed nonce jump from a known sender. Messages with a nonce that
+ * jumps more than this from the last confirmed nonce are rejected as suspicious.
+ * Does not apply to the first message from a new sender (baseline is 0). This
+ * is safe because a spoofed first message would fail decryption and its nonce
+ * would never be confirmed to storage.
+ *
+ * Trade-off: if the receiver goes offline and misses more than this many
+ * messages from a known sender, legitimate messages will be permanently
+ * blocked. In practice this is unlikely given low message rates in MWP
+ * sessions, but worth noting.
+ */
+const MAX_NONCE_JUMP = 100;
 /** The maximum number of retry attempts for publishing a message. */
 const MAX_RETRY_ATTEMPTS = 5;
 /** The base delay in milliseconds for exponential backoff between publish retries. */
@@ -65,6 +78,7 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
 	private readonly centrifuge: Centrifuge | SharedCentrifuge;
 	private readonly storage: WebSocketTransportStorage;
 	private readonly queue: QueuedItem[] = [];
+	private readonly pendingNonces = new Map<string, Set<number>>();
 	private isProcessingQueue = false;
 	private state: TransportState = "disconnected";
 
@@ -214,6 +228,9 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
 	 */
 	public async clear(channel: string): Promise<void> {
 		await this.storage.clear(channel);
+		for (const key of this.pendingNonces.keys()) {
+			if (key.startsWith(`${channel}:`)) this.pendingNonces.delete(key);
+		}
 		const sub = this.centrifuge.getSubscription(channel);
 		if (sub) this.centrifuge.removeSubscription(sub as Subscription);
 	}
@@ -229,6 +246,11 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
 
 	/**
 	 * Parses an incoming raw message, checks for duplicates, and emits it.
+	 *
+	 * The nonce is checked for deduplication but NOT persisted here. The emitted
+	 * payload includes a `confirmNonce` callback that the consumer (BaseClient)
+	 * must call after successful decryption. This prevents an attacker from
+	 * poisoning the nonce tracker with high-nonce messages that fail decryption.
 	 */
 	private async _handleIncomingMessage(channel: string, rawData: string): Promise<void> {
 		try {
@@ -246,13 +268,44 @@ export class WebSocketTransport extends EventEmitter implements ITransport {
 			const latestNonces = await this.storage.getLatestNonces(channel);
 			const latestNonce = latestNonces.get(message.clientId) || 0;
 
-			if (message.nonce > latestNonce) {
-				// This is a new message, update the latest nonce and emit the message.
-				latestNonces.set(message.clientId, message.nonce);
-				await this.storage.setLatestNonces(channel, latestNonces);
-				this.emit("message", { channel, data: message.payload });
+			if (message.nonce <= latestNonce) {
+				return;
 			}
-			// If message.nonce <= latestNonce, it's a duplicate and we ignore it.
+
+			// Reject suspiciously large nonce jumps (but allow first message from a new sender).
+			if (latestNonce > 0 && message.nonce - latestNonce > MAX_NONCE_JUMP) {
+				this.emit("error", new TransportError(ErrorCode.TRANSPORT_PARSE_FAILED, `Nonce jump too large: ${latestNonce} -> ${message.nonce}`));
+				return;
+			}
+
+			// Guard against duplicate processing between emit and confirm.
+			// Without this, a message arriving via both live publication and
+			// _fetchHistory could pass the storage-based dedup check twice
+			// because the nonce hasn't been confirmed yet.
+			const pendingKey = `${channel}:${message.clientId}`;
+			const pending = this.pendingNonces.get(pendingKey);
+			if (pending?.has(message.nonce)) {
+				return;
+			}
+			if (!pending) {
+				this.pendingNonces.set(pendingKey, new Set([message.nonce]));
+			} else {
+				pending.add(message.nonce);
+			}
+
+			const confirmNonce = async () => {
+				try {
+					await this.storage.confirmNonce(channel, message.clientId, message.nonce);
+				} catch (error) {
+					this.emit("error", new TransportError(ErrorCode.UNKNOWN, `Failed to confirm nonce: ${error instanceof Error ? error.message : String(error)}`));
+				}
+				const p = this.pendingNonces.get(pendingKey);
+				if (p) {
+					p.delete(message.nonce);
+					if (p.size === 0) this.pendingNonces.delete(pendingKey);
+				}
+			};
+			this.emit("message", { channel, data: message.payload, confirmNonce });
 		} catch (error) {
 			this.emit("error", new TransportError(ErrorCode.TRANSPORT_PARSE_FAILED, `Failed to parse incoming message: ${error instanceof Error ? error.message : "Unknown error"}`));
 		}


### PR DESCRIPTION
## Summary

Prevents nonce poisoning attacks by deferring nonce persistence until after successful decryption. Previously, nonces were saved immediately on message receipt, allowing an attacker to send high-nonce messages that fail decryption but permanently block legitimate messages.

- Nonce is now confirmed via callback only after successful decryption in `BaseClient`
- Added `MAX_NONCE_JUMP` (100) to reject suspiciously large nonce jumps from known senders
- Added `NaN` recovery in nonce storage
- Added mutex around `confirmNonce` to prevent concurrent race conditions

## Jira

- [WAPI-1121](https://metamask.atlassian.net/browse/WAPI-1121)

## Test plan

- [x] Unit tests for `confirmNonce`, NaN recovery, nonce regression prevention
- [x] All existing unit tests pass (63/63)
- [x] Lint passes

[WAPI-1121]: https://consensyssoftware.atlassian.net/browse/WAPI-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transport-level deduplication/nonce persistence behavior and introduces a new `confirmNonce` handshake between transport and client; mistakes could drop or permanently block legitimate messages (e.g., missed confirmations or nonce-jump threshold).
> 
> **Overview**
> Hardens inbound message handling against nonce-poisoning by **deferring persistence of received nonces until after successful decryption**: `WebSocketTransport` now emits `message` events with a `confirmNonce()` callback, and `BaseClient` calls it only when `decryptMessage` succeeds.
> 
> Adds additional nonce safety rails: rejects suspicious large nonce jumps from known senders (`MAX_NONCE_JUMP`), tracks *pending* nonces to avoid double-processing before confirmation, clears pending state on `clear()`, and makes nonce storage more robust via `NaN` recovery plus a mutex-protected `confirmNonce` path. Tests and changelog are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd3a662207b2a2337e89add2a40aec88cbe7cdd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->