### PR TITLE
fix: reject inbound messages on expired sessions (WAPI-1130)

### DIFF
--- a/apps/integration-tests/src/end-to-end.integration.test.ts
+++ b/apps/integration-tests/src/end-to-end.integration.test.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: test code */
 /** biome-ignore-all lint/suspicious/noShadowRestrictedNames: test code */
-import { type ConnectionMode, type IKeyManager, type IKVStore, type KeyPair, type SessionRequest, SessionStore, WebSocketTransport } from "@metamask/mobile-wallet-protocol-core";
+import { type ConnectionMode, ErrorCode, type IKeyManager, type IKVStore, type KeyPair, type SessionRequest, SessionStore, WebSocketTransport } from "@metamask/mobile-wallet-protocol-core";
 import { DappClient, type OtpRequiredPayload } from "@metamask/mobile-wallet-protocol-dapp-client";
 import { WalletClient } from "@metamask/mobile-wallet-protocol-wallet-client";
 import { decrypt, encrypt, PrivateKey, PublicKey } from "eciesjs";
@@ -188,6 +188,34 @@ t.describe("E2E Integration Test", () => {
 		const messageFromWalletPromise = new Promise((resolve) => dappClient.on("message", resolve));
 		await walletClient.sendResponse(responsePayload);
 		await t.expect(messageFromWalletPromise).resolves.toEqual(responsePayload);
+	});
+
+	t.test("should reject inbound messages on an expired session", async () => {
+		await connectClients(dappClient, walletClient, "trusted");
+
+		// Verify a message works pre-expiry
+		const preExpiryPayload = { method: "pre_expiry_check" };
+		const preExpiryPromise = new Promise((resolve) => walletClient.on("message", resolve));
+		await dappClient.sendRequest(preExpiryPayload);
+		await t.expect(preExpiryPromise).resolves.toEqual(preExpiryPayload);
+
+		// Force-expire the wallet's session
+		(walletClient as any).session.expiresAt = Date.now() - 1000;
+
+		const errorPromise = new Promise<any>((resolve) => {
+			walletClient.once("error", resolve);
+		});
+
+		// Send another message from dapp
+		await dappClient.sendRequest({ method: "post_expiry_check" });
+
+		// Wallet should emit SESSION_EXPIRED
+		const error = await errorPromise;
+		t.expect(error.code).toBe(ErrorCode.SESSION_EXPIRED);
+
+		// Wait briefly, confirm the message was NOT delivered
+		const walletMessagePromise = new Promise((resolve) => walletClient.once("message", resolve));
+		await assertPromiseNotResolve(walletMessagePromise, 500, "Wallet should not receive messages on expired session");
 	});
 
 	t.test("should successfully resume a previously established session", async () => {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject inbound messages on expired sessions instead of processing them
 - Fix `SessionStore` race conditions and fire-and-forget garbage collection ([#71](https://github.com/MetaMask/mobile-wallet-protocol/pull/71))
 - Guard against `NaN` in session expiry timestamps ([#70](https://github.com/MetaMask/mobile-wallet-protocol/pull/70))
 

--- a/packages/core/src/base-client.integration.test.ts
+++ b/packages/core/src/base-client.integration.test.ts
@@ -7,6 +7,7 @@ import * as t from "vitest";
 import WebSocket from "ws";
 import { BaseClient } from "./base-client";
 import { ClientState } from "./domain/client-state";
+import { ErrorCode } from "./domain/errors";
 import type { IKeyManager } from "./domain/key-manager";
 import type { KeyPair } from "./domain/key-pair";
 import type { IKVStore } from "./domain/kv-store";
@@ -366,6 +367,49 @@ t.describe("BaseClient", () => {
 
 		// 6. Restore the original method
 		publishSpy.mockRestore();
+	});
+
+	t.test("should reject inbound messages on an expired session", async () => {
+		const keyManagerA = new KeyManager();
+		const keyManagerB = new KeyManager();
+		const keyPairA = keyManagerA.generateKeyPair();
+		const keyPairB = keyManagerB.generateKeyPair();
+
+		const sessionA: Session = {
+			id: "session-inbound-expiry",
+			channel,
+			keyPair: keyPairA,
+			theirPublicKey: keyPairB.publicKey,
+			expiresAt: Date.now() + 60000,
+		};
+		const sessionB: Session = {
+			id: "session-inbound-expiry",
+			channel,
+			keyPair: keyPairB,
+			theirPublicKey: keyPairA.publicKey,
+			expiresAt: Date.now() - 1000, // Already expired
+		};
+
+		clientA.setSession(sessionA);
+		clientB.setSession(sessionB);
+
+		await clientA["transport"].subscribe(channel);
+		await clientB["transport"].subscribe(channel);
+
+		const errorPromise = new Promise<any>((resolve) => {
+			clientB.once("error", resolve);
+		});
+
+		const messageToSend: ProtocolMessage = { type: "message", payload: { method: "should_be_rejected" } };
+		await clientA.sendMessage(channel, messageToSend);
+
+		const error = await errorPromise;
+		t.expect(error.code).toBe(ErrorCode.SESSION_EXPIRED);
+
+		// Give a small window to ensure no message processing occurs
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		t.expect(clientB.receivedMessages).toHaveLength(0);
+		t.expect(clientB.getSession()).toBeNull();
 	});
 
 	t.test("should reject resume() when client is already connected", async () => {

--- a/packages/core/src/base-client.ts
+++ b/packages/core/src/base-client.ts
@@ -45,6 +45,10 @@ export abstract class BaseClient extends EventEmitter {
 
 		this.transport.on("message", async (payload) => {
 			if (!this.session?.keyPair.privateKey) return;
+			if (await this.checkSessionExpiry()) {
+				this.emit("error", new SessionError(ErrorCode.SESSION_EXPIRED, "Session expired"));
+				return;
+			}
 			const message = await this.decryptMessage(payload.data);
 			if (message) this.handleMessage(message);
 		});
@@ -140,7 +144,7 @@ export abstract class BaseClient extends EventEmitter {
 	 */
 	protected async sendMessage(channel: string, message: ProtocolMessage): Promise<void> {
 		if (!this.session) throw new SessionError(ErrorCode.SESSION_INVALID_STATE, "Cannot send message: session is not initialized.");
-		await this.checkSessionExpiry();
+		if (await this.checkSessionExpiry()) throw new SessionError(ErrorCode.SESSION_EXPIRED, "Session expired");
 		const plaintext = JSON.stringify(message);
 		const encrypted = await this.keymanager.encrypt(plaintext, this.session.theirPublicKey);
 		const ok = await this.transport.publish(channel, encrypted);
@@ -148,15 +152,14 @@ export abstract class BaseClient extends EventEmitter {
 	}
 
 	/**
-	 * Checks if the current session is expired. If it is, triggers a disconnect.
-	 * @throws {SessionError} if the session is expired.
+	 * Checks if the current session has expired. If so, triggers a disconnect.
+	 *
+	 * @returns true if the session was expired (and cleanup was triggered), false otherwise.
 	 */
-	private async checkSessionExpiry(): Promise<void> {
-		if (!this.session) return;
-		if (this.session.expiresAt < Date.now()) {
-			await this.disconnect();
-			throw new SessionError(ErrorCode.SESSION_EXPIRED, "Session expired");
-		}
+	private async checkSessionExpiry(): Promise<boolean> {
+		if (!this.session || this.session.expiresAt >= Date.now()) return false;
+		await this.disconnect();
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds session expiry check to the inbound message handler in `BaseClient`, closing a gap where only outbound messages were checked for expiry
- Expired inbound messages are silently discarded with an error event emitted and disconnect triggered

## Background

The Cyfrin audit identified that while `sendMessage()` checks for session expiry before sending, the `transport.on("message", ...)` handler did not perform any expiry check. This meant a message arriving on an expired session would still be decrypted and processed.

## Changes

- `packages/core/src/base-client.ts`: Unified `checkSessionExpiry()` method (returns `boolean`, handles disconnect + error emission). Used in both the inbound message handler (early return) and `sendMessage` (throws after check).
- `packages/core/src/base-client.integration.test.ts`: New test case for expired session message rejection
- `apps/integration-tests/src/end-to-end.integration.test.ts`: New E2E test verifying messages sent to an expired receiver are dropped and trigger SESSION_EXPIRED

## Test plan

- [x] `yarn build` passes
- [x] `yarn test:unit` passes (63/63 tests)
- [x] `yarn lint` passes (no new warnings)
- [x] Integration tests pass (8/8 tests, including new expired session test)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core message-handling and session lifecycle behavior; an incorrect expiry check or disconnect side effect could drop legitimate traffic or cause unexpected disconnects.
> 
> **Overview**
> **Expired sessions now block inbound traffic.** `BaseClient` adds a session-expiry gate in the transport message handler so messages arriving after `expiresAt` are rejected, a `SESSION_EXPIRED` error is emitted, and cleanup/disconnect is triggered.
> 
> `checkSessionExpiry()` is refactored to return a boolean and is reused by both inbound and outbound paths, with new integration/E2E tests asserting that post-expiry messages are not delivered. Dependency housekeeping pins `eciesjs` to `0.4.17` across apps/core (and updates `yarn.lock`) and records the fix in the core changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9827ff050a182c5c46556488e4d05e9dbb0e33ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->