### PR TITLE
fix: add runtime validation for ConnectionMode (WAPI-1129)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `isValidConnectionMode()` and `CONNECTION_MODES` for runtime validation of connection mode values
+
 ### Changed
 
 - Add `validatePeerKey` method to `IKeyManager` interface for peer public key validation at handshake and resume time ([#70](https://github.com/MetaMask/mobile-wallet-protocol/pull/70))

--- a/packages/core/src/domain/connection-mode.ts
+++ b/packages/core/src/domain/connection-mode.ts
@@ -3,4 +3,9 @@
  * 'trusted': A streamlined flow for same-device or trusted contexts that bypasses OTP.
  * 'untrusted': The high-security flow requiring user verification via OTP.
  */
-export type ConnectionMode = "trusted" | "untrusted";
+export const CONNECTION_MODES = ["trusted", "untrusted"] as const;
+export type ConnectionMode = (typeof CONNECTION_MODES)[number];
+
+export function isValidConnectionMode(value: unknown): value is ConnectionMode {
+	return typeof value === "string" && CONNECTION_MODES.includes(value as ConnectionMode);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { BaseClient } from "./base-client";
 export { ClientState } from "./domain/client-state";
-export type { ConnectionMode } from "./domain/connection-mode";
+export { CONNECTION_MODES, type ConnectionMode, isValidConnectionMode } from "./domain/connection-mode";
 export { CryptoError, ErrorCode, ProtocolError, SessionError, TransportError } from "./domain/errors";
 export type { IKeyManager } from "./domain/key-manager";
 export type { KeyPair } from "./domain/key-pair";

--- a/packages/dapp-client/src/client.ts
+++ b/packages/dapp-client/src/client.ts
@@ -7,6 +7,7 @@ import {
 	type IKeyManager,
 	type ISessionStore,
 	type ITransport,
+	isValidConnectionMode,
 	type Message,
 	type ProtocolMessage,
 	type Session,
@@ -107,9 +108,11 @@ export class DappClient extends BaseClient {
 	 */
 	public async connect(options: DappConnectOptions = {}): Promise<void> {
 		if (this.state !== ClientState.DISCONNECTED) throw new SessionError(ErrorCode.SESSION_INVALID_STATE, `Cannot connect when state is ${this.state}`);
-		this.state = ClientState.CONNECTING;
 
 		const { mode = "untrusted", initialPayload } = options;
+		if (!isValidConnectionMode(mode)) throw new SessionError(ErrorCode.SESSION_INVALID_STATE, `Invalid connection mode: "${String(mode)}"`);
+
+		this.state = ClientState.CONNECTING;
 		const { pendingSession, request } = this._createPendingSessionAndRequest(mode, initialPayload);
 		this.session = pendingSession;
 		this.emit("session_request", request);

--- a/packages/wallet-client/src/client.ts
+++ b/packages/wallet-client/src/client.ts
@@ -6,6 +6,7 @@ import {
 	type IKeyManager,
 	type ISessionStore,
 	type ITransport,
+	isValidConnectionMode,
 	type ProtocolMessage,
 	type Session,
 	SessionError,
@@ -77,10 +78,12 @@ export class WalletClient extends BaseClient {
 	 */
 	public async connect(options: { sessionRequest: SessionRequest }): Promise<void> {
 		if (this.state !== ClientState.DISCONNECTED) throw new SessionError(ErrorCode.SESSION_INVALID_STATE, `Cannot connect when state is ${this.state}`);
-		this.state = ClientState.CONNECTING;
 
 		const request = options.sessionRequest;
+		if (!isValidConnectionMode(request.mode)) throw new SessionError(ErrorCode.SESSION_INVALID_STATE, `Invalid connection mode: "${String(request.mode)}"`);
 		if (Date.now() > request.expiresAt) throw new SessionError(ErrorCode.REQUEST_EXPIRED, "Session request expired");
+
+		this.state = ClientState.CONNECTING;
 
 		const self = this;
 		const context: IConnectionHandlerContext = {


### PR DESCRIPTION
## Summary

- Adds runtime validation for `ConnectionMode` values at connect-time in both `WalletClient` and `DappClient`
- Exports `CONNECTION_MODES` const array and `isValidConnectionMode()` type guard from core
- Previously, an invalid mode like `"admin"` would silently fall through to the `UntrustedConnectionHandler` via the else branch

## Background

`ConnectionMode` was a TypeScript-only type (`"trusted" | "untrusted"`) with no runtime enforcement. Since `SessionRequest.mode` can come from external sources (e.g. a QR code, deep link, or cross-origin message), a malformed value would bypass type safety at runtime. The Cyfrin audit flagged this as needing runtime validation.

## Changes

- `packages/core/src/domain/connection-mode.ts`: Added `CONNECTION_MODES` const array and `isValidConnectionMode()` type guard
- `packages/core/src/index.ts`: Exports the new symbols
- `packages/wallet-client/src/client.ts`: Validates `request.mode` before handler selection
- `packages/dapp-client/src/client.ts`: Validates `mode` before creating session request
- `packages/core/CHANGELOG.md`: Documents the new exports

## Test plan

- [x] `yarn build` passes
- [x] `yarn test:unit` passes (68/68 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change that adds runtime guarding of externally-sourced `mode` values and only affects connect-time error handling/flow selection.
> 
> **Overview**
> Adds runtime validation for `ConnectionMode` by introducing `CONNECTION_MODES` and the `isValidConnectionMode()` type guard in core and exporting them publicly.
> 
> Updates `DappClient.connect()` and `WalletClient.connect()` to reject invalid `mode` values (throwing `SessionError`) before entering `CONNECTING` and selecting a connection handler, preventing unexpected fall-through to the untrusted flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b20564c4378bf3b61fc95e2b8d42f6c6b3d1c824. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->