### PR TITLE
fix: publish the ESM build of @metamask/mobile-wallet-protocol-core

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Publish the ESM build by adding `module` and `exports` to the manifest, so `dist/index.mjs` is reachable instead of always resolving to the CommonJS build
+- Publish the ESM build by adding `module` and `exports` to the manifest, so `dist/index.mjs` is reachable instead of always resolving to the CommonJS build ([#85](https://github.com/MetaMask/mobile-wallet-protocol/pull/85))
 
 ## [0.4.0]
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Publish the ESM build by adding `module` and `exports` to the manifest, so `dist/index.mjs` is reachable instead of always resolving to the CommonJS build
+
 ## [0.4.0]
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,20 @@
 	},
 	"license": "MIT",
 	"main": "./dist/index.js",
+	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/index.d.mts",
+				"default": "./dist/index.mjs"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
+		}
+	},
 	"files": [
 		"dist"
 	],


### PR DESCRIPTION
**Description**

- FIXED:
  - `packages/core` builds both CJS and ESM (`tsup src/index.ts --format cjs,esm --dts --splitting`) but its manifest declares only `main` + `types`, so the published `dist/index.mjs` and `dist/index.d.mts` are unreachable and every bundler resolves the CommonJS build. This adds `module` + `exports`.

`dapp-client` and `wallet-client` — same repo, same build script — already declare both fields. `core` is the only package without them, so this copies their block verbatim.

**Why it matters**

Resolved as CJS, `await import('@metamask/mobile-wallet-protocol-core')` gives esbuild-based bundlers a namespace whose named members are `undefined`. `@metamask/connect-multichain` does exactly that in `#createDappClient()`, so `mwpCore.SessionStore.create(kvstore)` throws `undefined is not an object` in any browser build of MetaMask Connect — reproduced on Angular 22 / esbuild, where connecting via the MWP QR flow fails outright. We currently ship this change as a `pnpm patch`.

**Issue**

Reported downstream as MetaMask/connect-monorepo#342, which covers two bugs of the same kind — this change fixes the `mwpCore.SessionStore` half of it.

**Checklist**

- [ ] Tests are included if applicable — manifest-only change, no test surface
- [x] Any added code is fully documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only change with no runtime code edits; aligns core with sibling packages and fixes incorrect module resolution for ESM consumers.
> 
> **Overview**
> **Fixes `@metamask/mobile-wallet-protocol-core` always resolving to CommonJS** even though `tsup` already emits `dist/index.mjs` and `dist/index.d.mts`.
> 
> Adds `module` and a conditional `exports` map (ESM `import` → `.mjs` / `.d.mts`, CJS `require` → `.js` / `.d.ts`), matching the other packages in this repo. The changelog records the fix under **Unreleased → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144461c21e147de9a062c8d53efd4287e083c1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
